### PR TITLE
Nodeをv22に変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
   actions: read
 
 env:
-  node-version: "21.6.2"
+  node-version: "22.0.0"
 
 jobs:
   build:


### PR DESCRIPTION
次のリポジトリにないバージョンはキャッシュされないため、v22にする。
https://github.com/actions/node-versions